### PR TITLE
Commit only added plugin files, not --all

### DIFF
--- a/wp-cli-git-helper.php
+++ b/wp-cli-git-helper.php
@@ -75,7 +75,7 @@ class Git_Helper_Command extends WP_CLI_Command {
 
 			$message = vsprintf( $message_formats[ $action ], $message_args );
 
-			$repo->commit( $message );
+			$repo->commit( $message, false );
 		}
 	}
 


### PR DESCRIPTION
The second parameter of `$repo->commit` defaults to true, which adds the `--all` parameter to the subsequent `git commit`. This adds unstaged files in the current directory alongside the specified plugin files to the commit. This bug only shows up when using the `wp gh` command in a folder that contains unstaged tracked files that have been modified.