### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "boonebgorges/wp-cli-git-helper",
-	"type": "command",
+	"type": "wp-cli-package",
 	"description": "Git helper for wp-cli core, plugin, and theme commands",
 	"keywords": ["wp-cli", "git"],
 	"homepage": "https://github.com/boonebgorges/wp-cli-git-helper",


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
